### PR TITLE
Release 2.0.0: upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A lightweight client to easily call the MyInfo TUO endpoint for the Singapore government. Compatible with NodeJS version >=6.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This version breaks backwards compatibility with NodeJS <10.