### PR TITLE
build: release 2.1.0 - migrate to TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A lightweight client to easily call the MyInfo TUO endpoint for the Singapore government. Compatible with NodeJS version >=6.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This release migrates the library to TypeScript and exports several types for the convenience of upstream libraries. The API remains the same.