### PR TITLE
feat: introduce prepublish hook to run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "npm run build && npx nyc --reporter=text mocha --recursive",
     "lint": "eslint --ext .ts --ignore-pattern '*.d.ts' --ignore-path .gitignore --fix .",
-    "build": "tsc"
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This helps developers to avoid errors during the manual NPM publication process whereby a package is published without the build folder.