### PR TITLE
fix: move JSON.parse to decrypt function

### DIFF
--- a/src/MyInfoGovClient.class.ts
+++ b/src/MyInfoGovClient.class.ts
@@ -477,11 +477,10 @@ export class MyInfoGovClient {
 
     return keystore
       .add(this.privateKey, 'pem')
-      .then(jweKey => {
+      .then((jweKey) => {
         return jose.JWE.createDecrypt(jweKey).decrypt(jweResponse)
       })
-      .then(result => result.payload.toString())
-      .then(JSON.parse)
+      .then(({ payload }) => JSON.parse(payload.toString()))
   }
 
   /**

--- a/src/MyInfoGovClient.class.ts
+++ b/src/MyInfoGovClient.class.ts
@@ -39,6 +39,9 @@ interface IBaseStringSpec {
   txnNo?: string
 }
 
+type MyInfoParsedResponse = Omit<IPersonBasic, 'uinFin'>
+type MyInfoResponse = MyInfoParsedResponse | string
+
 const BASE_URL: { [M in Mode]: string } = {
   [Mode.Dev]: 'https://myinfosgstg.api.gov.sg/gov/dev/v1/',
   [Mode.Staging]: 'https://myinfosgstg.api.gov.sg/gov/test/v2/',
@@ -446,18 +449,21 @@ export class MyInfoGovClient {
       singpassEserviceId,
       txnNo: txnNo,
     }
-
-    return axios.get(url, {
+    return axios.get<MyInfoResponse>(url, {
       headers,
       params: querystring,
       paramsSerializer: (params) => qs.stringify(params),
     })
       .then((response) =>
-        this.mode === Mode.Dev ? Promise.resolve(response.data) : this._decryptJwe(response.data),
+        // In dev mode, Axios parses the response for us, otherwise we need to decrypt the JWE
+        typeof response.data === 'string' ? this._decryptJwe(response.data) : Promise.resolve(response.data),
       )
-      .then(personObject => {
-        personObject.uinFin = uinFin
-        return personObject
+      .then((personObject) => {
+        const personWithUinFin: IPersonBasic = {
+          ...personObject,
+          uinFin,
+        }
+        return personWithUinFin
       })
   }
 
@@ -466,7 +472,7 @@ export class MyInfoGovClient {
    *    @param jweResponse Fullstop-delimited jweResponse string
    *    @return Promise which resolves to a JSON string
    */
-  _decryptJwe (jweResponse: string): Promise<string> {
+  _decryptJwe (jweResponse: string): Promise<MyInfoParsedResponse> {
     const keystore = jose.JWK.createKeyStore()
 
     return keystore

--- a/src/MyInfoGovClient.class.ts
+++ b/src/MyInfoGovClient.class.ts
@@ -470,7 +470,7 @@ export class MyInfoGovClient {
   /**
    *    Decrypts a JWE response string
    *    @param jweResponse Fullstop-delimited jweResponse string
-   *    @return Promise which resolves to a JSON string
+   *    @return Promise which resolves to a parsed response
    */
   _decryptJwe (jweResponse: string): Promise<MyInfoParsedResponse> {
     const keystore = jose.JWK.createKeyStore()

--- a/src/MyInfoGovClient.class.ts
+++ b/src/MyInfoGovClient.class.ts
@@ -455,7 +455,6 @@ export class MyInfoGovClient {
       .then((response) =>
         this.mode === Mode.Dev ? Promise.resolve(response.data) : this._decryptJwe(response.data),
       )
-      .then(JSON.parse)
       .then(personObject => {
         personObject.uinFin = uinFin
         return personObject
@@ -476,6 +475,7 @@ export class MyInfoGovClient {
         return jose.JWE.createDecrypt(jweKey).decrypt(jweResponse)
       })
       .then(result => result.payload.toString())
+      .then(JSON.parse)
   }
 
   /**

--- a/test/src/MyInfoGovClient.test.js
+++ b/test/src/MyInfoGovClient.test.js
@@ -13,7 +13,7 @@ const SAMPLE_RESPONSE = fs.readFileSync(
 
 const MOCK_RESPONSE = {
   statusCode: 200,
-  data: JSON.stringify({ mockKey: 'mockValue' }),
+  data: { mockKey: 'mockValue' },
 }
 
 const ALL_ATTRIBUTES = [
@@ -137,7 +137,7 @@ describe('MyInfoGovClient', function () {
     it('should parse the response correctly', function (done) {
       const axiosStub = {
         get: function () {
-          return Promise.resolve({ data: SAMPLE_RESPONSE.toString() })
+          return Promise.resolve({ data: JSON.parse(SAMPLE_RESPONSE.toString()) })
         },
       }
 


### PR DESCRIPTION
## Problem

#9 broke the dev environment due to a JSON parsing error.

The problem comes about because Axios automatically parses JSON data in dev mode, but not in staging/prod. This is because in dev mode, we receive a JSON stringified object which can be parsed by Axios, whereas in staging/prod, we receive a JWE string which needs to be decrypted. As a result, `JSON.parse` is correctly called in staging/prod, but causes an error in dev.

## Solution
Instead of relying on the `Mode` (thus making this information implicit), change the conditional to call `_decryptJwe` based on the type, then call `JSON.parse` in `_decryptJwe`. Also, tighten up the Axios types.