### PR TITLE
build: release 2.1.2 - fix dev mode error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A lightweight client to easily call the MyInfo TUO endpoint for the Singapore government. Compatible with NodeJS version >=6.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This patch fixes a bug where JSON.parse throws an error in `dev` mode.