### PR TITLE
build: only include build files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A lightweight client to easily call the MyInfo Person v3.2 endpoint for the Singapore government. Tested with NodeJS version >=12.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "test-unit": "jest",
     "test-e2e": "env-cmd -f test/.test-env concurrently --success first --kill-others \"mockpass\" \"testcafe\"",


### PR DESCRIPTION
This results in the following outcome for `npm publish --dry-run`:
![image](https://user-images.githubusercontent.com/29480346/108679994-46173600-7528-11eb-9a15-88c9512cd58c.png)
