### PR TITLE
fix: make nested scope data optional

### DIFF
--- a/src/types/childrenbirthrecords.ts
+++ b/src/types/childrenbirthrecords.ts
@@ -1,6 +1,6 @@
 import { MyInfoField, StringValue, CodeAndDesc, MyInfoAttribute } from './base'
 
-type MyInfoChildFull = {
+type MyInfoChildFull = Partial<{
   birthcertno: StringValue
   name: StringValue
   hanyupinyinname: StringValue
@@ -14,7 +14,7 @@ type MyInfoChildFull = {
   lifestatus: CodeAndDesc
   dob: StringValue
   tob: StringValue
-}
+}>
 
 export type MyInfoChildBirthRecordBelow21 = MyInfoChildFull
 export type MyInfoChildBirthRecordAbove21 = Pick<MyInfoChildFull, 'birthcertno'>

--- a/src/types/drivinglicence.ts
+++ b/src/types/drivinglicence.ts
@@ -6,24 +6,27 @@ import {
   MyInfoAttribute,
 } from './base'
 
-type StartEndDate = {
+type StartEndDate = Partial<{
   startdate: StringValue
   enddate: StringValue
-}
-type PDL = {
+}>
+
+type PDL = Partial<{
   validity: CodeAndDesc
   expirydate: StringValue
   classes: { class: StringValue }[]
-}
-type QDL = {
+}>
+
+type QDL = Partial<{
   validity: CodeAndDesc
   expirydate: StringValue
   classes: {
     class: StringValue
     issuedate: StringValue
   }[]
-}
-type DrivingLicenceCustomFields = {
+}>
+
+type DrivingLicenceCustomFields = Partial<{
   comstatus: CodeAndDesc
   totaldemeritpoints: NumberValue
   suspension: StartEndDate
@@ -32,7 +35,7 @@ type DrivingLicenceCustomFields = {
   pdl: PDL
   qdl: QDL
   photocardserialno: StringValue
-}
+}>
 
 export type MyInfoDrivingLicence = MyInfoField<DrivingLicenceCustomFields>
 export type DrivingLicenceScope =

--- a/src/types/hdbownership.ts
+++ b/src/types/hdbownership.ts
@@ -7,7 +7,7 @@ import {
   StringValue,
 } from './base'
 
-type HdbOwnershipCustomFields = {
+type HdbOwnershipCustomFields = Partial<{
   noofowners: NumberValue
   address: MyInfoSingaporeAddress | MyInfoUnformattedAddress
   hdbtype: CodeAndDesc
@@ -23,7 +23,7 @@ type HdbOwnershipCustomFields = {
   }
   outstandingloanbalance: NumberValue
   monthlyloaninstalment: NumberValue
-}
+}>
 
 export type MyInfoHdbOwnership = MyInfoField<HdbOwnershipCustomFields>
 export type HdbOwnershipScope = `${MyInfoAttribute.HDBOwnership}.${keyof HdbOwnershipCustomFields}`

--- a/src/types/sponsoredchildrenrecords.ts
+++ b/src/types/sponsoredchildrenrecords.ts
@@ -6,7 +6,7 @@ import {
   MyInfoNotApplicable,
 } from './base'
 
-export type MyInfoSponsoredChildFull = {
+export type MyInfoSponsoredChildFull = Partial<{
   nric: StringValue
   name: StringValue
   hanyupinyinname: StringValue
@@ -23,7 +23,7 @@ export type MyInfoSponsoredChildFull = {
   residentialstatus: CodeAndDesc
   nationality: CodeAndDesc
   scprgrantdate: StringValue
-}
+}>
 
 export type MyInfoSponsoredChildBelow21 = MyInfoSponsoredChildFull
 export type MyInfoSponsoredChildAbove21 = Pick<MyInfoSponsoredChildFull, 'nric'>

--- a/src/types/vehicles.ts
+++ b/src/types/vehicles.ts
@@ -6,7 +6,7 @@ import {
   MyInfoAttribute,
 } from './base'
 
-export type MyInfoVehicleFull = {
+export type MyInfoVehicleFull = Partial<{
   vehicleno: StringValue
   type: StringValue
   iulabelno: StringValue
@@ -44,7 +44,7 @@ export type MyInfoVehicleFull = {
   minimumparfbenefit: NumberValue
   nooftransfers: NumberValue
   vpc: StringValue
-}
+}>
 
 export type MyInfoVehicle = MyInfoField<MyInfoVehicleFull>
 export type VehiclesScope = `${MyInfoAttribute.Vehicles}.${keyof MyInfoVehicleFull}`


### PR DESCRIPTION
## Problem

Closes #29 

## Solution

Make nested fields optional for all MyInfo scopes that allow it:

- `childrenbirthrecords`
- `drivinglicence`
- `hdbownership`
- `sponsoredchildrenrecords`
- `vehicles`

For `drivinglicence`, the doubly-nested `StartEndDate`, `PDL` and `QDL` had to be made `Partial` as well.