### PR TITLE
build: release v4.0.0 - reorganise MyInfo data types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A lightweight client to easily call the MyInfo Person v3.2 endpoint for the Singapore government. Tested with NodeJS version >=12.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Breaking changes

### Renaming of types
The following data types were renamed:
- `AddressType` to `MyInfoAddressType`
- `FieldWithCodeAndDesc` to `MyInfoCodeField`
- `ChildBelow21` to `MyInfoChildBirthRecordBelow21`
- `ChildAbove21` to `MyInfoChildBirthRecordAbove21`
- `DrivingLicence` to `MyInfoDrivingLicence`
- `GSTVoucher` to `MyInfoGstVoucher`
- `HDBOwnership` to `MyInfoHdbOwnership`
- `HouseholdIncome` to `MyInfoHouseholdIncome`
- `MerdekaGen` to `MyInfoMerdekaGen`
- `NOABasic` to `MyInfoNoaBasic`
- `NOAFull` to `MyInfoNoa`
- `NOAHistoryBasic` to `MyInfoNoaHistoryBasic`
- `NOAHistoryFull` to `MyInfoNoaHistory`
- `OwnerPrivate` to `MyInfoOwnerPrivate`
- `SilverSupport` to `MyInfoSilverSupport`
- `SponsoredChildBelow21` to `MyInfoSponsoredChildBelow21`
- `SponsoredChildAbove21` to `MyInfoSponsoredChildAbove21`

### Nested scope data made optional
Nested fields were previously typed as all being present, e.g. if `vehicles` was present then `vehicles.vehicleno`, `vehicles.type` etc were typed as being present. This has been made more strict: all nested fields are now optional, regardless of which scopes were retrieved.

## Improvements
- Various new data types exported
- NPM package now only includes the minimum necessary files
- Repo is now linted
- Dependency upgrades