### PR TITLE
fix/source - constrain "source" and "value" properties to allowable values, improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ typings/
 main.js
 secrets/*
 build
+
+# macOS
+.DS_Store

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -38,13 +38,21 @@ export type MyInfoUnavailableField<
 
 export type MyInfoAvailableMetadata<
   S extends MyInfoSource
-> = MyInfoApplicable<S> & Partial<UnavailableProp<undefined>> // For convenience
+> = MyInfoApplicable<S> & Partial<UnavailableProp<undefined>>
+// Note on Partial<UnavailableProp<undefined>>:
+//
+// This is included for syntactic convenience so that code such as the below can be compiled in TypeScript:
+//
+//   if (!data.unavailable) {...}
+//
+// In reality, if it exists, the value of "unavailable" property is always false.
+// This is a design quirk of the MyInfo API.
 
 export type MyInfoField<T, S extends MyInfoSource = MyInfoSourceDefault> =
   | MyInfoUnavailableField<S>
   | (T & MyInfoAvailableMetadata<S>)
 
-type ValueType<T> = {
+type ValueType<T extends string | number | boolean> = {
   value: T
 }
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -46,7 +46,7 @@ export type MyInfoAvailableMetadata<
 //
 //   if (!data.unavailable) {...}
 //
-// In reality, if it exists, the value of "unavailable" property is always false.
+// In reality, if it exists, the value of "unavailable" property is always true.
 // This is a design quirk of the MyInfo API.
 
 export type MyInfoField<T, S extends MyInfoSource = MyInfoSourceDefault> =

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -9,7 +9,7 @@ export enum MyInfoDataClassification {
   Confidential = 'C',
 }
 
-type SourceProp<T> = {
+type SourceProp<T extends MyInfoSource> = {
   source: T
 }
 
@@ -23,7 +23,7 @@ type MyInfoSourceDefault = Exclude<MyInfoSource, MyInfoSource.NotApplicable>
 // For a full reference, see https://www.ndi-api.gov.sg/library/myinfo/implementation-myinfo-data
 export type MyInfoNotApplicable = SourceProp<MyInfoSource.NotApplicable>
 
-export type MyInfoApplicable<S> = {
+export type MyInfoApplicable<S extends MyInfoSource> = {
   lastupdated: string
   classification: MyInfoDataClassification.Confidential
 } & SourceProp<S>
@@ -32,13 +32,15 @@ type UnavailableProp<T> = {
   unavailable: T
 }
 
-export type MyInfoUnavailableField<S> = MyInfoApplicable<S> &
-  UnavailableProp<true>
+export type MyInfoUnavailableField<
+  S extends MyInfoSource
+> = MyInfoApplicable<S> & UnavailableProp<true>
 
-export type MyInfoAvailableMetadata<S> = MyInfoApplicable<S> &
-  Partial<UnavailableProp<undefined>> // For convenience
+export type MyInfoAvailableMetadata<
+  S extends MyInfoSource
+> = MyInfoApplicable<S> & Partial<UnavailableProp<undefined>> // For convenience
 
-export type MyInfoField<T, S = MyInfoSourceDefault> =
+export type MyInfoField<T, S extends MyInfoSource = MyInfoSourceDefault> =
   | MyInfoUnavailableField<S>
   | (T & MyInfoAvailableMetadata<S>)
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -24,7 +24,8 @@ type MyInfoSourceDefault = Exclude<MyInfoSource, MyInfoSource.NotApplicable>
 export type MyInfoNotApplicable = SourceProp<MyInfoSource.NotApplicable>
 
 export type MyInfoApplicable<S extends MyInfoSource> = {
-  lastupdated: string
+  // The “lastupdated” field is not always non-empty currently, but under what circumstances this occurs is unknown
+  lastupdated?: string
   classification: MyInfoDataClassification.Confidential
 } & SourceProp<S>
 


### PR DESCRIPTION
The types in this repository document our understanding of the MyInfo API responses. After drawing the MyInfo team's attention to the typing present in this repository, it was realised that various generics in use could be more accurately defined, with no loss of compatibility with existing code.

Comments was also added to explain a quirk with the `unavailable` property in the MyInfo response, as well as address the possibility that the `lastupdated` field may not be present.
