### PR TITLE
chore: bump to 4.0.2 after node-jose upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A lightweight client to easily call the MyInfo Person v3.2 endpoint for the Singapore government. Tested with NodeJS version >=12.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Version bump to 4.0.2