### PR TITLE
fix: fix wrong type for MyInfo Children vaccination and bump version to v4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/myinfo-gov-client",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A lightweight client to easily call the MyInfo Person v3.2 endpoint for the Singapore government. Tested with NodeJS version >=12.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/types/childrenbirthrecords.ts
+++ b/src/types/childrenbirthrecords.ts
@@ -25,7 +25,7 @@ type MyInfoChildFull = Partial<{
   lifestatus: CodeAndDesc
   dob: StringValue
   tob: StringValue
-  vaccinationrequirements: VaccinationRequirements
+  vaccinationrequirements: VaccinationRequirements[]
 }>
 
 export type MyInfoChildBirthRecordBelow21 = MyInfoChildFull

--- a/src/types/childrenbirthrecords.ts
+++ b/src/types/childrenbirthrecords.ts
@@ -1,4 +1,4 @@
-import { MyInfoField, StringValue, CodeAndDesc, MyInfoAttribute } from './base'
+import { MyInfoField, StringValue, CodeAndDesc, MyInfoAttribute, BooleanValue } from './base'
 
 type MyInfoChildFull = Partial<{
   birthcertno: StringValue
@@ -14,8 +14,13 @@ type MyInfoChildFull = Partial<{
   lifestatus: CodeAndDesc
   dob: StringValue
   tob: StringValue
-  vaccinationrequirements: StringValue
+  vaccinationrequirements: VaccinationRequirements
 }>
+
+type VaccinationRequirements = {
+  requirement: CodeAndDesc,
+  fulfilled: BooleanValue
+}
 
 export type MyInfoChildBirthRecordBelow21 = MyInfoChildFull
 export type MyInfoChildBirthRecordAbove21 = Pick<MyInfoChildFull, 'birthcertno'>

--- a/src/types/childrenbirthrecords.ts
+++ b/src/types/childrenbirthrecords.ts
@@ -3,7 +3,7 @@ import {
   StringValue,
   CodeAndDesc,
   MyInfoAttribute,
-  BooleanValue
+  BooleanValue,
 } from './base'
 
 type VaccinationRequirements = {

--- a/src/types/childrenbirthrecords.ts
+++ b/src/types/childrenbirthrecords.ts
@@ -1,4 +1,15 @@
-import { MyInfoField, StringValue, CodeAndDesc, MyInfoAttribute, BooleanValue } from './base'
+import {
+  MyInfoField,
+  StringValue,
+  CodeAndDesc,
+  MyInfoAttribute,
+  BooleanValue
+} from './base'
+
+type VaccinationRequirements = {
+  requirement: CodeAndDesc
+  fulfilled: BooleanValue
+}
 
 type MyInfoChildFull = Partial<{
   birthcertno: StringValue
@@ -16,11 +27,6 @@ type MyInfoChildFull = Partial<{
   tob: StringValue
   vaccinationrequirements: VaccinationRequirements
 }>
-
-type VaccinationRequirements = {
-  requirement: CodeAndDesc,
-  fulfilled: BooleanValue
-}
 
 export type MyInfoChildBirthRecordBelow21 = MyInfoChildFull
 export type MyInfoChildBirthRecordAbove21 = Pick<MyInfoChildFull, 'birthcertno'>


### PR DESCRIPTION
## Problem

The type declaration for MyInfo Chldren does not follow the Swagger API's definition.

See https://public.cloud.myinfo.gov.sg/myinfo/api/myinfo-kyc-v4.0.html

## Solution

I made sure the data shape fits it.
