### PR TITLE
chore(workflow): add missing permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for pushing tags
+      packages: write # for publishing packages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

GitHub Actions workflow for npm publishing fails due to missing permissions.

## Solution

Add permissions required for pushing tags and publishing packages.